### PR TITLE
feat: make renaming function cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.suo
 SIS Renamer/bin/
 SIS Renamer/obj/
+.vs
+.idea


### PR DESCRIPTION
This PR improves the performance of the renaming function and makes it cross-platform compatible (tested with Mono on Linux).
It also ensures unique filenames by appending _number to the end of clashing filenames.

There are a few calls to showErrorMessage() when a rename op fails. Please let me know if this is undesirable.